### PR TITLE
Support Images without Extensions

### DIFF
--- a/Thumbnailer.php
+++ b/Thumbnailer.php
@@ -20,6 +20,7 @@ use yii\helpers\FileHelper;
 use yii\helpers\Url;
 use yii\imagine\Image as Imagine;
 use yii\caching\CacheInterface;
+use yii\helpers\Inflector;
 
 /**
  * Image thumbnailer for Yii2.
@@ -125,8 +126,8 @@ class Thumbnailer extends Component
             $url = Yii::getAlias("{$host}{$url}");
         }
 
-        $entities = array('%2F', '%3A', '?', '=', '&');
-        $replacements = array("/", ':', '-', '-', '-');
+        $entities = array('%2F', '%3A');
+        $replacements = array("/", ':');
         $testUrl = str_replace($entities, $replacements, urlencode($url));
         if (!filter_var($testUrl, FILTER_VALIDATE_URL)) {
             throw new InvalidArgumentException(Yii::t('app', $testUrl.' expects a valid URL'));
@@ -247,7 +248,7 @@ class Thumbnailer extends Component
         $ignore_certificate = false
         )
     {
-        $filename = basename($url);
+        $filename = uniqid(Inflector::slug(basename($url)));
         $thumbnailPath = Yii::getAlias("$this->thumbnailsPath/{$width}x{$height}/{$filename}");
 
         try {

--- a/Thumbnailer.php
+++ b/Thumbnailer.php
@@ -263,7 +263,7 @@ class Thumbnailer extends Component
         }
         if(! $extension)
         {
-            $contentType = @FileHelper::getMimeType($url) ?: ((array_change_key_case(get_headers($uri,true))['content-type']) ?? null);
+            $contentType = @FileHelper::getMimeType($url) ?: ((array_change_key_case(get_headers($url,true))['content-type']) ?? null);
             $extension = $contentType ? (current( FileHelper::getExtensionsByMimeType($contentType)) ?? 'jpg') : 'jpg';
         }
         

--- a/Thumbnailer.php
+++ b/Thumbnailer.php
@@ -248,8 +248,26 @@ class Thumbnailer extends Component
         $ignore_certificate = false
         )
     {
-        $filename = uniqid(Inflector::slug(basename($url)));
-        $thumbnailPath = Yii::getAlias("$this->thumbnailsPath/{$width}x{$height}/{$filename}");
+        $urlparts = parse_url($url);
+        $hash = ($urlparts['query'] ?? null) ? ('-'.md5($urlparts['query'])) : '';
+        if($urlparts['path'] ?? null)
+        {
+            $path = $urlparts['path'];
+            $filename = pathinfo($path)['filename'] ?? null;
+            $filename = $filename ? Inflector::slug($filename) : null;
+            $extension = pathinfo($path)['extension'] ?? null;
+        }
+        if(!$filename)
+        {
+            $filename = uniqid('thumbnail-');
+        }
+        if(! $extension)
+        {
+            $contentType = FileHelper::getMimeType($url) ?: ((array_change_key_case(get_headers($uri,true))['content-type']) ?? null);
+            $extension = $contentType ? (current( FileHelper::getExtensionsByMimeType($contentType)) ?? 'jpg') : 'jpg';
+        }
+        
+        $thumbnailPath = Yii::getAlias("$this->thumbnailsPath/{$width}x{$height}/{$filename}{$hash}.{$extension}");
 
         try {
             if ($ignore_certificate){

--- a/Thumbnailer.php
+++ b/Thumbnailer.php
@@ -21,6 +21,7 @@ use yii\helpers\Url;
 use yii\imagine\Image as Imagine;
 use yii\caching\CacheInterface;
 use yii\helpers\Inflector;
+use Mimey\MimeTypes;
 
 /**
  * Image thumbnailer for Yii2.
@@ -263,8 +264,9 @@ class Thumbnailer extends Component
         }
         if(! $extension)
         {
+            $mimes = new MimeTypes;
             $contentType = @FileHelper::getMimeType($url) ?: ((array_change_key_case(get_headers($url,true))['content-type']) ?? null);
-            $extension = $contentType ? (current( FileHelper::getExtensionsByMimeType($contentType)) ?? 'jpg') : 'jpg';
+            $extension = $contentType ? ($mimes->getExtension($contentType) ?? 'jpg') : 'jpg';
         }
         Yii::warning(['filename' => $filename, 'extension' => $extension, 'hash' => $hash, 'urlparts' => $urlparts],"Generating Thumbnail based on $url");
         $thumbnailPath = Yii::getAlias("$this->thumbnailsPath/{$width}x{$height}/{$filename}{$hash}.{$extension}");

--- a/Thumbnailer.php
+++ b/Thumbnailer.php
@@ -266,7 +266,7 @@ class Thumbnailer extends Component
             $contentType = @FileHelper::getMimeType($url) ?: ((array_change_key_case(get_headers($url,true))['content-type']) ?? null);
             $extension = $contentType ? (current( FileHelper::getExtensionsByMimeType($contentType)) ?? 'jpg') : 'jpg';
         }
-        
+        Yii::warning(['filename' => $filename, 'extension' => $extension, 'hash' => $hash, 'urlparts' => $urlparts],"Generating Thumbnail based on $url");
         $thumbnailPath = Yii::getAlias("$this->thumbnailsPath/{$width}x{$height}/{$filename}{$hash}.{$extension}");
 
         try {

--- a/Thumbnailer.php
+++ b/Thumbnailer.php
@@ -263,7 +263,7 @@ class Thumbnailer extends Component
         }
         if(! $extension)
         {
-            $contentType = FileHelper::getMimeType($url) ?: ((array_change_key_case(get_headers($uri,true))['content-type']) ?? null);
+            $contentType = @FileHelper::getMimeType($url) ?: ((array_change_key_case(get_headers($uri,true))['content-type']) ?? null);
             $extension = $contentType ? (current( FileHelper::getExtensionsByMimeType($contentType)) ?? 'jpg') : 'jpg';
         }
         

--- a/Thumbnailer.php
+++ b/Thumbnailer.php
@@ -125,8 +125,8 @@ class Thumbnailer extends Component
             $url = Yii::getAlias("{$host}{$url}");
         }
 
-        $entities = array('%2F', '%3A');
-        $replacements = array("/", ':');
+        $entities = array('%2F', '%3A', '?', '=', '&');
+        $replacements = array("/", ':', '-', '-', '-');
         $testUrl = str_replace($entities, $replacements, urlencode($url));
         if (!filter_var($testUrl, FILTER_VALIDATE_URL)) {
             throw new InvalidArgumentException(Yii::t('app', $testUrl.' expects a valid URL'));

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "yiisoft/yii2": "*",
-        "yiisoft/yii2-imagine": "~2.2.0"
+        "yiisoft/yii2-imagine": "~2.2.0",
+        "ralouphie/mimey": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
One problem with the extension is that a URL that looks like this: https://domain.com/download?id=123 doesn't have a file extension.  The thumbnailer still works fine if this is the case (as long as the thumb is used in an `<img>` tag), but in many default setups the image will bear the content-type "application/octet-stream".  If this image is linked to, it will download rather than showing in the browser window by default.  This causes it to fail, for example, when used with GLightBox.

This PR adds a dependency, which is needed because Yii2's FileHelper::getExtensionsByMimeType returns silly answers for common MIMEs.  For example, Yii2's answer to "image/jpeg" is ".jfif".  By default, httpd will serve .jfif as application/octet-stream.

The MIME type is determined either using FileHelper::getMimeType() which fails for URLs, or using get_headers() to fetch the Content-Type of the remote image.

I also added Inflector::slug to correct unusual characters in the filename which caused problems with file retrieval, and hashed the querystring.  This just makes the generated names a little more sane and removes characters like "&", "?", and "=".